### PR TITLE
Added Missing Executes for SceneTags

### DIFF
--- a/src/main/java/emu/grasscutter/game/quest/exec/ExecAddSceneTag.java
+++ b/src/main/java/emu/grasscutter/game/quest/exec/ExecAddSceneTag.java
@@ -1,0 +1,20 @@
+package emu.grasscutter.game.quest.exec;
+
+import emu.grasscutter.data.excels.quest.QuestData;
+import emu.grasscutter.game.quest.*;
+import emu.grasscutter.game.quest.enums.QuestExec;
+import emu.grasscutter.game.quest.handlers.QuestExecHandler;
+import emu.grasscutter.scripts.ScriptLib;
+import java.util.Arrays;
+
+@QuestValueExec(QuestExec.QUEST_EXEC_ADD_SCENE_TAG)
+public final class ExecAddSceneTag extends QuestExecHandler {
+    @Override
+    public boolean execute(GameQuest quest, QuestData.QuestExecParam condition, String... paramStr) {
+        var param =
+                Arrays.stream(paramStr).filter(i -> !i.isBlank()).mapToInt(Integer::parseInt).toArray();
+		quest.getOwner().getProgressManager().addSceneTag(param[0], param[1]);
+		
+        return true;
+    }
+}

--- a/src/main/java/emu/grasscutter/game/quest/exec/ExecDelSceneTag.java
+++ b/src/main/java/emu/grasscutter/game/quest/exec/ExecDelSceneTag.java
@@ -1,0 +1,19 @@
+package emu.grasscutter.game.quest.exec;
+
+import emu.grasscutter.data.excels.quest.QuestData;
+import emu.grasscutter.game.quest.*;
+import emu.grasscutter.game.quest.enums.QuestExec;
+import emu.grasscutter.game.quest.handlers.QuestExecHandler;
+import java.util.Arrays;
+
+@QuestValueExec(QuestExec.QUEST_EXEC_DEL_SCENE_TAG)
+public final class ExecDelSceneTag extends QuestExecHandler {
+    @Override
+    public boolean execute(GameQuest quest, QuestData.QuestExecParam condition, String... paramStr) {
+        var param =
+                Arrays.stream(paramStr).filter(i -> !i.isBlank()).mapToInt(Integer::parseInt).toArray();
+		quest.getOwner().getProgressManager().delSceneTag(param[0], param[1]);
+		
+        return true;
+    }
+}


### PR DESCRIPTION
Added 2 missing classes for adding and deleting sceneTags in quests

## Description

Added 2 missing Execute Classes for quests for adding and deleting sceneTag. 
[src/main/java/emu/grasscutter/game/quest/exec/ExecAddSceneTag.java]
[src/main/java/emu/grasscutter/game/quest/exec/ExecDelSceneTag.java]


## Issues fixed by this PR

World quests such as (Seirai Stormchasers) changing sceneTag such as the Thunder Manifestation platform would not change after finishing the quest.

## Type of changes

<!--- Put an `x` in all the boxes that apply your changes. -->

- [x] Bug fix
- [ ] New feature 
- [ ] Enhancement
- [ ] Documentation

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My pull request is unique and no other pull requests have been opened for these changes
- [x] I have read the [Contributing note](https://github.com/Grasscutters/Grasscutter/blob/stable/CONTRIBUTING.md) and [Code of conduct](https://github.com/Grasscutters/Grasscutter/blob/development/CODE_OF_CONDUCT.md)
- [x] I am responsible for any copyright issues with my code if it occurs in the future.
